### PR TITLE
Update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
-script: "bundle exec rspec spec"
+script: "bundle exec rake"
 
 language: ruby
 
 rvm:
   - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.0
+  - 2.3.0


### PR DESCRIPTION
- Alter run command to `bundle exec rake`
- Add Travis support for Ruby versions 2.0, 2.1, 2.2, 2.3