### PR TITLE
Adds differentiation between nil and NO_VALUE

### DIFF
--- a/lib/hash_diff.rb
+++ b/lib/hash_diff.rb
@@ -2,6 +2,8 @@ require "hash_diff/version"
 require "hash_diff/comparison"
 
 module HashDiff
+  class NO_VALUE; end
+
   def self.patch!
     Hash.class_eval do
       def diff(right)

--- a/lib/hash_diff/comparison.rb
+++ b/lib/hash_diff/comparison.rb
@@ -38,7 +38,7 @@ module HashDiff
     end
 
     def equal?(key)
-      left[key] == right[key]
+      value_with_default(left, key) == value_with_default(right, key)
     end
 
     def hash?(value)
@@ -53,8 +53,15 @@ module HashDiff
       if comparable?(key)
         self.class.new(left[key], right[key]).find_differences(&reporter)
       else
-        reporter.call(left[key], right[key])
+        reporter.call(
+          value_with_default(left, key),
+          value_with_default(right, key)
+        )
       end
+    end
+
+    def value_with_default(obj, key)
+      obj.fetch(key, NO_VALUE)
     end
   end
 end

--- a/spec/hash_diff/comparison_spec.rb
+++ b/spec/hash_diff/comparison_spec.rb
@@ -2,10 +2,37 @@ require "spec_helper"
 
 describe HashDiff::Comparison do
 
-  let(:app_v1_properties) { { foo: 'bar',  bar: 'foo',  nested: { foo: 'bar',  bar: { one: 'foo1' } }, num: 1 } }
-  let(:app_v2_properties) { { foo: 'bar2', bar: 'foo2', nested: { foo: 'bar2', bar: { two: 'foo2' } }, word: 'monkey' } }
+  let(:app_v1_properties) {
+    {
+      foo: 'bar',
+      bar: 'foo',
+      nested: {
+        foo: 'bar',
+        bar: {
+          one: 'foo1'
+        }
+      },
+      num: 1,
+      word: nil
+    }
+  }
+  let(:app_v2_properties) {
+    {
+      foo: 'bar2',
+      bar: 'foo2',
+      nested: {
+        foo: 'bar2',
+        bar: {
+          two: 'foo2'
+        }
+      },
+      word: 'monkey'
+    }
+  }
 
-  subject(:comparison) { HashDiff::Comparison.new(app_v1_properties, app_v2_properties) }
+  subject(:comparison) {
+    HashDiff::Comparison.new(app_v1_properties, app_v2_properties)
+  }
 
   describe "#diff" do
     subject { comparison.diff }
@@ -18,11 +45,11 @@ describe HashDiff::Comparison do
           nested: {
             foo: ["bar", "bar2"],
             bar: {
-              one: ["foo1", nil],
-              two: [nil, "foo2"]
+              one: ["foo1", HashDiff::NO_VALUE],
+              two: [HashDiff::NO_VALUE, "foo2"]
             }
           },
-          num:  [1, nil],
+          num:  [1, HashDiff::NO_VALUE],
           word: [nil, "monkey"]
         }
       }
@@ -57,11 +84,11 @@ describe HashDiff::Comparison do
         nested: {
           foo: "bar2",
           bar: {
-            one: nil,
+            one: HashDiff::NO_VALUE,
             two: "foo2"
           }
         },
-        num:  nil,
+        num:  HashDiff::NO_VALUE,
         word: "monkey"
       }
     }
@@ -80,7 +107,7 @@ describe HashDiff::Comparison do
           foo: "bar",
           bar: {
             one: "foo1",
-            two: nil
+            two: HashDiff::NO_VALUE
           }
         },
         num:  1,


### PR DESCRIPTION
When a given key does not exist on either side we were returning nil.
This makes it so we return HashDiff::NO_VALUE instead of nil if the key
is not found.

Fixes #2 