### PR TITLE
Update Dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
-script: "bundle exec rspec spec"
+script: "bundle exec rake"
 
 language: ruby
 
 rvm:
-  - 1.9.3
+  - 2.5
+  - 2.6

--- a/hash_diff.gemspec
+++ b/hash_diff.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 3.1"
+  spec.add_development_dependency "rspec", "~> 3.9.0"
 end


### PR DESCRIPTION
This is a follow up to https://github.com/CodingZeal/hash_diff/pull/3.  Updating the travis config as well as using only supported Ruby versions.

**Changes:**
- 🙈 Add vscode to gitignore
- ⬆️ Bump bundler and rspec dev dependencies
- 👷‍♂️ Use default rake task for travis build