### PR TITLE
Fix comparison

### DIFF
--- a/lib/hash_diff/comparison.rb
+++ b/lib/hash_diff/comparison.rb
@@ -35,7 +35,7 @@ module HashDiff
 
     def combined_keys
       if hash?(left) && hash?(right) then
-        (left.keys + right.keys).uniq.sort
+        (left.keys + right.keys).uniq
       elsif array?(left) && array?(right) then
         (0..[left.size, right.size].max).to_a
       else

--- a/spec/hash_diff/comparison_spec.rb
+++ b/spec/hash_diff/comparison_spec.rb
@@ -72,6 +72,19 @@ describe HashDiff::Comparison do
         it { expect(subject).to be_empty }
       end
     end
+
+    context "when hashes have both symbol and string keys" do
+      let(:app_v1_properties) { { foo: "bar" } }
+      let(:app_v2_properties) { { "foo" => "bar" } }
+      let(:diff) do
+        {
+          foo: ["bar", HashDiff::NO_VALUE],
+          "foo" => [HashDiff::NO_VALUE, "bar"]
+        }
+      end
+
+      it { expect(subject).to eq(diff) }
+    end
   end
 
   describe "#left_diff" do


### PR DESCRIPTION
Remove unnecessary sort from `HashDiff#combined_keys` method that is
raising an exception when hashes have both symbol and string keys.

Resolves #10 